### PR TITLE
feat(ui): update TopNav brand to GeoQuery, add new nav links and Import page demo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,16 +7,19 @@ import TopNav, { TopNavLink } from "@/components/layout/TopNav";
 import Footer from "@/components/layout/Footer";
 
 const links: TopNavLink[] = [
-  { label: "Dashboard" },      // -> /
-  { label: "Upload Data" },    // -> /upload
-  { label: "Saved Queries" },  // -> /history
-  { label: "Tutorials" },      // -> /tutorials
+  { label: "Home" },       // -> /
+  { label: "Dashboard" },  // -> /dashboard
+  { label: "History" },    // -> /history
+  { label: "Import" },     // -> /upload
+  { label: "Result" },     // -> /result
+  { label: "Tutorials" },  // -> /tutorials
+  { label: "About" },      // -> /about
 ];
 
 function App() {
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-purple-600 to-blue-600">
-      <TopNav brand="GeoAnswering" links={links} />
+      <TopNav brand="GeoQuery" links={links} />
 
       <main className="flex-1 p-8">
         <div className="max-w-6xl mx-auto">
@@ -24,7 +27,7 @@ function App() {
           <div className="text-center mb-16">
             <div className="flex items-center justify-center mb-6">
               <MapPin className="w-12 h-12 text-white mr-3" />
-              <h1 className="text-5xl font-bold text-white">GeoAnswering</h1>
+              <h1 className="text-5xl font-bold text-white">GeoQuery</h1>
             </div>
             <p className="text-xl text-white/90 mb-2">Ask Your Map Anything</p>
             <p className="text-white/80 max-w-2xl mx-auto">
@@ -102,7 +105,7 @@ function App() {
         </div>
       </main>
 
-      <Footer brand="GeoAnswering" />
+      <Footer brand="GeoQuery" />
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -5,6 +6,7 @@ import { MapPin, BarChart3, Globe } from "lucide-react";
 
 import TopNav, { TopNavLink } from "@/components/layout/TopNav";
 import Footer from "@/components/layout/Footer";
+import ImportPage from "@/pages/Import"; // 新增导入页面
 
 const links: TopNavLink[] = [
   { label: "Home" },       // -> /
@@ -16,95 +18,108 @@ const links: TopNavLink[] = [
   { label: "About" },      // -> /about
 ];
 
+// 提取首页现有内容为一个组件，方便条件渲染
+function HomeView() {
+  return (
+    <div className="max-w-6xl mx-auto">
+      {/* Header Section */}
+      <div className="text-center mb-16">
+        <div className="flex items-center justify-center mb-6">
+          <MapPin className="w-12 h-12 text-white mr-3" />
+          <h1 className="text-5xl font-bold text-white">GeoQuery</h1>
+        </div>
+        <p className="text-xl text-white/90 mb-2">Ask Your Map Anything</p>
+        <p className="text-white/80 max-w-2xl mx-auto">
+          Transform natural language into powerful geographic insights. Query,
+          analyze, and visualize spatial data like never before.
+        </p>
+      </div>
+
+      {/* Search Section */}
+      <div className="max-w-4xl mx-auto mb-16">
+        <div className="flex gap-4">
+          <Input
+            placeholder="Try: 'Show me population density in California'"
+            className="bg-white/90 backdrop-blur-sm border-0 rounded-lg px-6 py-4 text-gray-700 placeholder-gray-500 focus:ring-2 focus:ring-white/30 text-lg flex-1"
+          />
+          <Button className="bg-white text-purple-600 hover:bg-gray-50 font-medium px-8 py-4 text-lg transition-all duration-200 hover:scale-105">
+            Try Demo →
+          </Button>
+        </div>
+      </div>
+
+      {/* Feature Cards */}
+      <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+        <Card className="backdrop-blur-sm bg-white/10 border-white/20 hover:bg-white/15 transition-all duration-300 hover:scale-105">
+          <CardHeader className="text-center">
+            <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
+              <MapPin className="w-8 h-8 text-white" />
+            </div>
+            <CardTitle className="text-white text-xl">Natural Language</CardTitle>
+            <CardDescription className="text-white/80">
+              Ask questions in plain English
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-white/70 text-center">
+              Transform your questions into powerful geographic insights with our advanced natural language processing.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="backdrop-blur-sm bg-white/10 border-white/20 hover:bg-white/15 transition-all duration-300 hover:scale-105">
+          <CardHeader className="text-center">
+            <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
+              <BarChart3 className="w-8 h-8 text-white" />
+            </div>
+            <CardTitle className="text-white text-xl">Smart Analytics</CardTitle>
+            <CardDescription className="text-white/80">
+              Get instant insights and visualizations
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-white/70 text-center">
+              Analyze spatial data with intelligent algorithms that provide meaningful insights and beautiful visualizations.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="backdrop-blur-sm bg-white/10 border-white/20 hover:bg-white/15 transition-all duration-300 hover:scale-105">
+          <CardHeader className="text-center">
+            <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Globe className="w-8 h-8 text-white" />
+            </div>
+            <CardTitle className="text-white text-xl">Interactive Maps</CardTitle>
+            <CardDescription className="text-white/80">
+              Explore data with dynamic mapping
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-white/70 text-center">
+              Interact with your data through dynamic, responsive maps that bring geographic information to life.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
 function App() {
+  const [path, setPath] = useState(() => window.location.pathname);
+
+  useEffect(() => {
+    const onPop = () => setPath(window.location.pathname);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-purple-600 to-blue-600">
       <TopNav brand="GeoQuery" links={links} />
-
       <main className="flex-1 p-8">
-        <div className="max-w-6xl mx-auto">
-          {/* Header Section */}
-          <div className="text-center mb-16">
-            <div className="flex items-center justify-center mb-6">
-              <MapPin className="w-12 h-12 text-white mr-3" />
-              <h1 className="text-5xl font-bold text-white">GeoQuery</h1>
-            </div>
-            <p className="text-xl text-white/90 mb-2">Ask Your Map Anything</p>
-            <p className="text-white/80 max-w-2xl mx-auto">
-              Transform natural language into powerful geographic insights. Query,
-              analyze, and visualize spatial data like never before.
-            </p>
-          </div>
-
-          {/* Search Section */}
-          <div className="max-w-4xl mx-auto mb-16">
-            <div className="flex gap-4">
-              <Input
-                placeholder="Try: 'Show me population density in California'"
-                className="bg-white/90 backdrop-blur-sm border-0 rounded-lg px-6 py-4 text-gray-700 placeholder-gray-500 focus:ring-2 focus:ring-white/30 text-lg flex-1"
-              />
-              <Button className="bg-white text-purple-600 hover:bg-gray-50 font-medium px-8 py-4 text-lg transition-all duration-200 hover:scale-105">
-                Try Demo →
-              </Button>
-            </div>
-          </div>
-
-          {/* Feature Cards */}
-          <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-            <Card className="backdrop-blur-sm bg-white/10 border-white/20 hover:bg-white/15 transition-all duration-300 hover:scale-105">
-              <CardHeader className="text-center">
-                <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <MapPin className="w-8 h-8 text-white" />
-                </div>
-                <CardTitle className="text-white text-xl">Natural Language</CardTitle>
-                <CardDescription className="text-white/80">
-                  Ask questions in plain English
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <p className="text-white/70 text-center">
-                  Transform your questions into powerful geographic insights with our advanced natural language processing.
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card className="backdrop-blur-sm bg-white/10 border-white/20 hover:bg-white/15 transition-all duration-300 hover:scale-105">
-              <CardHeader className="text-center">
-                <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <BarChart3 className="w-8 h-8 text-white" />
-                </div>
-                <CardTitle className="text-white text-xl">Smart Analytics</CardTitle>
-                <CardDescription className="text-white/80">
-                  Get instant insights and visualizations
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <p className="text-white/70 text-center">
-                  Analyze spatial data with intelligent algorithms that provide meaningful insights and beautiful visualizations.
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card className="backdrop-blur-sm bg-white/10 border-white/20 hover:bg-white/15 transition-all duration-300 hover:scale-105">
-              <CardHeader className="text-center">
-                <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <Globe className="w-8 h-8 text-white" />
-                </div>
-                <CardTitle className="text-white text-xl">Interactive Maps</CardTitle>
-                <CardDescription className="text-white/80">
-                  Explore data with dynamic mapping
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <p className="text-white/70 text-center">
-                  Interact with your data through dynamic, responsive maps that bring geographic information to life.
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
+        {path === "/upload" ? <ImportPage /> : <HomeView />}
       </main>
-
       <Footer brand="GeoQuery" />
     </div>
   );

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -6,7 +6,7 @@ export type FooterProps = {
   year?: number;
 };
 
-export default function Footer({ className = "", brand = "GeoAnswering", year = new Date().getFullYear() }: FooterProps) {
+export default function Footer({ className = "", brand = "GeoQuery", year = new Date().getFullYear() }: FooterProps) {
   return (
     <footer role="contentinfo" className={`border-t border-border bg-background text-foreground/70 ${className}`}>
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6 text-sm flex flex-col gap-3 md:flex-row md:items-center md:justify-between">

--- a/frontend/src/components/layout/TopNav.tsx
+++ b/frontend/src/components/layout/TopNav.tsx
@@ -1,24 +1,38 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Menu, X, Sun, Moon, User } from "lucide-react";
 
+/** Allowed labels for the top navigation */
 export type TopNavLink = {
-  label: "Dashboard" | "Upload Data" | "Saved Queries" | "Tutorials";
+  label:
+    | "Home"
+    | "Dashboard"
+    | "History"
+    | "Import"
+    | "Result"
+    | "Tutorials"
+    | "About";
   onClick?: () => void;
 };
 
+/** Component props */
 export type TopNavProps = {
   brand?: string;
   links: TopNavLink[];
-  rightArea?: React.ReactNode; // custom right-side area (overrides default Theme+Avatar)
+  rightArea?: React.ReactNode; // optional custom right-side area
 };
 
+/** Label → path mapping used for naive client-side navigation */
 const LABEL_TO_PATH: Record<TopNavLink["label"], string> = {
-  "Dashboard": "/",
-  "Upload Data": "/upload",
-  "Saved Queries": "/history",   // per your request
-  "Tutorials": "/tutorials",
+  Home: "/",
+  Dashboard: "/dashboard", // now distinct from Home
+  History: "/history",
+  Import: "/upload",
+  Result: "/result",
+  Tutorials: "/tutorials",
+  About: "/about",
 };
 
+/** Track current pathname and update on browser navigation */
 function useActivePath() {
   const [path, setPath] = useState<string>(() => window.location.pathname);
   useEffect(() => {
@@ -29,6 +43,7 @@ function useActivePath() {
   return path;
 }
 
+/** Default right area: theme toggle + avatar placeholder */
 function DefaultRightArea() {
   return (
     <div className="flex items-center gap-3">
@@ -38,6 +53,7 @@ function DefaultRightArea() {
   );
 }
 
+/** Accessible theme toggle button that persists user preference */
 function ThemeToggle() {
   const [isDark, setIsDark] = useState<boolean>(() =>
     document.documentElement.classList.contains("dark")
@@ -55,11 +71,8 @@ function ThemeToggle() {
   }, [isDark]);
 
   useEffect(() => {
-    // hydrate from saved preference
     const saved = localStorage.getItem("theme");
-    if (saved === "dark") {
-      setIsDark(true);
-    }
+    if (saved === "dark") setIsDark(true);
   }, []);
 
   return (
@@ -74,6 +87,7 @@ function ThemeToggle() {
   );
 }
 
+/** Simple avatar placeholder button */
 function AvatarPlaceholder() {
   return (
     <button
@@ -86,7 +100,12 @@ function AvatarPlaceholder() {
   );
 }
 
-export default function TopNav({ brand = "GeoAnswering", links, rightArea }: TopNavProps) {
+/** Top navigation with responsive drawer */
+export default function TopNav({
+  brand = "GeoQuery",
+  links,
+  rightArea,
+}: TopNavProps) {
   const activePath = useActivePath();
   const [open, setOpen] = useState(false);
 
@@ -102,9 +121,10 @@ export default function TopNav({ brand = "GeoAnswering", links, rightArea }: Top
   const handleNavigate = (href: string, onClick?: () => void) => {
     if (onClick) {
       onClick();
+      setOpen(false);
       return;
     }
-    // naive client-side navigation (works without react-router)
+    // Naive client-side navigation (works without a router)
     if (window.location.pathname !== href) {
       window.history.pushState({}, "", href);
       window.dispatchEvent(new PopStateEvent("popstate"));
@@ -119,7 +139,7 @@ export default function TopNav({ brand = "GeoAnswering", links, rightArea }: Top
         aria-label="Top Navigation"
         role="navigation"
       >
-        {/* Left: Brand */}
+        {/* Brand */}
         <div className="flex items-center gap-2">
           <a
             href="/"
@@ -133,7 +153,7 @@ export default function TopNav({ brand = "GeoAnswering", links, rightArea }: Top
           </a>
         </div>
 
-        {/* Desktop Links */}
+        {/* Desktop links */}
         <div className="ml-6 hidden md:flex items-center gap-1">
           {items.map(({ label, href, onClick }) => {
             const active = activePath === href;
@@ -155,10 +175,12 @@ export default function TopNav({ brand = "GeoAnswering", links, rightArea }: Top
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Right Area */}
-        <div className="hidden md:flex items-center">{rightArea ?? <DefaultRightArea />}</div>
+        {/* Right area */}
+        <div className="hidden md:flex items-center">
+          {rightArea ?? <DefaultRightArea />}
+        </div>
 
-        {/* Mobile Toggle */}
+        {/* Mobile toggle */}
         <button
           type="button"
           className="ml-2 inline-flex md:hidden items-center justify-center h-9 w-9 rounded-md border border-border"
@@ -170,7 +192,7 @@ export default function TopNav({ brand = "GeoAnswering", links, rightArea }: Top
         </button>
       </nav>
 
-      {/* Mobile Drawer */}
+      {/* Mobile drawer */}
       {open && (
         <div className="md:hidden border-t border-border bg-background">
           <div className="px-4 py-3 space-y-1">
@@ -199,3 +221,4 @@ export default function TopNav({ brand = "GeoAnswering", links, rightArea }: Top
     </header>
   );
 }
+

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Upload } from "lucide-react";
+
+/** Import page placeholder */
+export default function Import() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <header className="mb-8 text-center">
+        <div className="mx-auto mb-4 w-16 h-16 rounded-full bg-white/20 flex items-center justify-center">
+          <Upload className="w-8 h-8 text-white" />
+        </div>
+        <h1 className="text-3xl font-semibold text-white">Import</h1>
+        <p className="text-white/80">
+          This is the Import page. Future upload functionality will be added here.
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-white/20 bg-white/10 backdrop-blur-sm p-6 text-white/90">
+        <p>
+          Replace this block with your actual import form and logic later. For now, it serves as a placeholder to validate navigation to <code>/upload</code>.
+        </p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Summary
- Updated TopNav to display brand name **GeoQuery** instead of the old name.
- Expanded navigation links to include: Home, Dashboard, History, Import, Result, Tutorials, About.
- Mapped Dashboard to `/dashboard` and Import to `/upload`.
- Added an Import page placeholder and App.tsx routing logic to demonstrate navigation works.

### Changes
- **TopNav.tsx**: Added new nav labels and paths; brand default updated.
- **App.tsx**: 
  - Updated TopNav links array.
  - Added Import page conditional rendering using `window.location.pathname`.
  - Extracted Home content into `HomeView` for cleaner routing.
- **Import.tsx**: New placeholder page for `/upload`.

### Testing
- Ran `npm run dev` and manually verified:
  - Navigation bar shows GeoQuery with new links.
  - Clicking "Import" navigates to `/upload` and renders Import placeholder.
  - Other links work as expected.

### Notes
This is the initial step for the Import feature. Future commits will add actual upload logic to `Import.tsx`.

### Related Issue
Closes #21 