### PR TITLE
feat: add About & History pages, frontend-only auth, and UI refinements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { MapPin, BarChart3, Globe, Send, Sparkles } from "lucide-react";
 import TopNav, { TopNavLink } from "@/components/layout/TopNav";
 import Footer from "@/components/layout/Footer";
 
-import ImportPage from "@/pages/Import";
+// import ImportPage from "@/pages/Import";
 import Login from "@/pages/Login";
 import Register from "@/pages/Register";
 import UserPage from "@/pages/User";
@@ -16,7 +16,7 @@ const links: TopNavLink[] = [
   { label: "Home" },
   { label: "Dashboard" },
   { label: "History" },
-  { label: "Import" },
+  // { label: "Import" }, 
   { label: "Result" },
   { label: "Tutorials" },
   { label: "About" },
@@ -30,10 +30,9 @@ function HomeView({ onQuery }: { onQuery: (query: string) => void }) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!query.trim()) return;
-    
+
     setIsLoading(true);
-    // Simulate processing time
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 500));
     onQuery(query.trim());
     setIsLoading(false);
   };
@@ -42,7 +41,7 @@ function HomeView({ onQuery }: { onQuery: (query: string) => void }) {
     "Find the largest cities near rivers in Europe",
     "Show population density of coastal areas in Asia",
     "What are the highest mountains in South America?",
-    "Analyze forest coverage in tropical regions"
+    "Analyze forest coverage in tropical regions",
   ];
 
   const handleSuggestionClick = (suggestion: string) => {
@@ -75,19 +74,19 @@ function HomeView({ onQuery }: { onQuery: (query: string) => void }) {
                     placeholder="Ask about geographic data, locations, demographics, climate patterns..."
                     className="w-full bg-transparent text-white placeholder-white/60 border-none outline-none resize-none px-4 py-3 text-lg leading-6 min-h-[3rem] max-h-32"
                     rows={1}
-                    style={{ 
-                      resize: 'none',
-                      overflow: 'hidden',
-                      height: 'auto',
-                      minHeight: '3rem'
+                    style={{
+                      resize: "none",
+                      overflow: "hidden",
+                      height: "auto",
+                      minHeight: "3rem",
                     }}
                     onInput={(e) => {
                       const target = e.target as HTMLTextAreaElement;
-                      target.style.height = 'auto';
-                      target.style.height = Math.min(target.scrollHeight, 128) + 'px';
+                      target.style.height = "auto";
+                      target.style.height = Math.min(target.scrollHeight, 128) + "px";
                     }}
                     onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !e.shiftKey) {
+                      if (e.key === "Enter" && !e.shiftKey) {
                         e.preventDefault();
                         handleSubmit(e);
                       }
@@ -167,13 +166,6 @@ export default function App() {
     return () => window.removeEventListener("popstate", onPop);
   }, []);
 
-  // Guard: guests cannot access /upload; redirect to /login
-  useEffect(() => {
-    if (!user && path === "/upload") {
-      window.history.pushState({}, "", "/login");
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }
-  }, [user, path]);
 
   const isAuthed = !!user;
 
@@ -187,7 +179,6 @@ export default function App() {
 
   /** Handle query submission from homepage */
   const handleQuery = (query: string) => {
-    // Store the user's query and navigate to results page
     setUserQuery(query);
     go("/result");
   };
@@ -223,7 +214,6 @@ export default function App() {
 
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-purple-600/80 to-blue-600/85">
-      {/* Top navigation: passes auth state, avatar and sign-out handlers */}
       <TopNav
         brand="GeoQuery"
         links={links}
@@ -233,7 +223,6 @@ export default function App() {
       />
 
       <main className="flex-1 p-8">
-        {/* Simple view switching based on pathname */}
         {path === "/login" && (
           <Login onLogin={handleLogin} onGoRegister={() => go("/register")} />
         )}
@@ -244,15 +233,12 @@ export default function App() {
 
         {path === "/user" && isAuthed && <UserPage email={user!.email} />}
 
-        {path === "/upload" && isAuthed && <ImportPage />}
-
         {path === "/result" && <GeoQueryResults query={userQuery} />}
 
         {/* Default homepage */}
         {path !== "/login" &&
           path !== "/register" &&
           path !== "/user" &&
-          path !== "/upload" &&
           path !== "/result" && <HomeView onQuery={handleQuery} />}
       </main>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,12 @@ import { MapPin, BarChart3, Globe, Send, Sparkles } from "lucide-react";
 import TopNav, { TopNavLink } from "@/components/layout/TopNav";
 import Footer from "@/components/layout/Footer";
 
-// import ImportPage from "@/pages/Import";
 import Login from "@/pages/Login";
 import Register from "@/pages/Register";
 import UserPage from "@/pages/User";
 import GeoQueryResults from "@/pages/Result";
 import HistoryPage from "@/pages/History";
+import AboutPage from "@/pages/About"; // <-- NEW
 
 import { getStoredUser, setStoredUser, User } from "@/lib/auth";
 
@@ -17,7 +17,6 @@ const links: TopNavLink[] = [
   { label: "Home" },
   { label: "Dashboard" },
   { label: "History" },
-  // { label: "Import" },
   { label: "Result" },
   { label: "Tutorials" },
   { label: "About" },
@@ -97,12 +96,12 @@ function HomeView({ onQuery }: { onQuery: (query: string) => void }) {
                 <button
                   type="submit"
                   disabled={!query.trim() || isLoading}
-                  className="ml-2 mr-2 p-3 bg-white/20 hover:bg-white/30 disabled:bg-white/10 disabled:cursor-not-allowed rounded-xl transition-all duration-200 group"
+                  className="ml-2 mr-2 p-3 bg白/20 hover:bg-white/30 disabled:bg-white/10 disabled:cursor-not-allowed rounded-xl transition-all duration-200 group"
                 >
                   {isLoading ? (
                     <Sparkles className="w-5 h-5 text-white/70 animate-spin" />
                   ) : (
-                    <Send className="w-5 h-5 text-white group-hover:text-white/90 disabled:text-white/50" />
+                    <Send className="w-5 h-5 text白 group-hover:text-white/90 disabled:text-white/50" />
                   )}
                 </button>
               </div>
@@ -140,12 +139,12 @@ function HomeView({ onQuery }: { onQuery: (query: string) => void }) {
           <h3 className="text-white text-xl text-center mb-1">Smart Analytics</h3>
           <p className="text-white/70 text-center">Get instant insights and visualizations.</p>
         </div>
-        <div className="backdrop-blur-sm bg-white/10 border-white/20 hover:bg-white/15 transition-all duration-300 hover:scale-105 rounded-lg p-6">
-          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Globe className="w-8 h-8 text-white" />
+        <div className="backdrop-blur-sm bg白/10 border白/20 hover:bg白/15 transition-all duration-300 hover:scale-105 rounded-lg p-6">
+          <div className="w-16 h-16 bg白/20 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Globe className="w-8 h-8 text白" />
           </div>
-          <h3 className="text-white text-xl text-center mb-1">Interactive Maps</h3>
-          <p className="text-white/70 text-center">Explore data with dynamic mapping.</p>
+          <h3 className="text白 text-xl text-center mb-1">Interactive Maps</h3>
+          <p className="text白/70 text-center">Explore data with dynamic mapping.</p>
         </div>
       </div>
     </div>
@@ -154,11 +153,8 @@ function HomeView({ onQuery }: { onQuery: (query: string) => void }) {
 
 /** App shell with naive client-side routing and frontend-only auth */
 export default function App() {
-  // Track current path to switch views without a router
   const [path, setPath] = useState(() => window.location.pathname);
-  // Auth state persisted to localStorage (frontend-only)
   const [user, setUser] = useState<User | null>(() => getStoredUser());
-  // Store the user's query to pass to results page
   const [userQuery, setUserQuery] = useState<string>("");
 
   useEffect(() => {
@@ -169,7 +165,6 @@ export default function App() {
 
   const isAuthed = !!user;
 
-  /** Push-state navigation helper */
   const go = (to: string) => {
     if (window.location.pathname !== to) {
       window.history.pushState({}, "", to);
@@ -177,13 +172,11 @@ export default function App() {
     }
   };
 
-  /** Handle query submission from homepage */
   const handleQuery = (query: string) => {
     setUserQuery(query);
     go("/result");
   };
 
-  /** Login success handler (frontend-only) */
   const handleLogin = (email: string) => {
     const next = { email };
     setUser(next);
@@ -191,7 +184,6 @@ export default function App() {
     go("/");
   };
 
-  /** Register success handler (frontend-only) */
   const handleRegister = (email: string) => {
     const next = { email };
     setUser(next);
@@ -199,14 +191,12 @@ export default function App() {
     go("/");
   };
 
-  /** Sign out handler */
   const handleLogout = () => {
     setUser(null);
     setStoredUser(null);
     go("/");
   };
 
-  /** Avatar behavior: guest → /login; authed → /user */
   const onAvatarClick = () => {
     if (!isAuthed) go("/login");
     else go("/user");
@@ -237,8 +227,10 @@ export default function App() {
 
         {path === "/history" && <HistoryPage />}
 
+        {path === "/about" && <AboutPage />}{/* <-- NEW */}
+
         {/* Default homepage (mutually exclusive) */}
-        {["/login", "/register", "/user", "/result", "/history"].includes(path)
+        {["/login", "/register", "/user", "/result", "/history", "/about"].includes(path)
           ? null
           : <HomeView onQuery={handleQuery} />}
       </main>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,15 +8,16 @@ import Login from "@/pages/Login";
 import Register from "@/pages/Register";
 import UserPage from "@/pages/User";
 import GeoQueryResults from "@/pages/Result";
+import HistoryPage from "@/pages/History";
 
 import { getStoredUser, setStoredUser, User } from "@/lib/auth";
 
-/** Top navigation links; TopNav will hide History for guests */
+/** Top navigation links */
 const links: TopNavLink[] = [
   { label: "Home" },
   { label: "Dashboard" },
   { label: "History" },
-  // { label: "Import" }, 
+  // { label: "Import" },
   { label: "Result" },
   { label: "Tutorials" },
   { label: "About" },
@@ -166,7 +167,6 @@ export default function App() {
     return () => window.removeEventListener("popstate", onPop);
   }, []);
 
-
   const isAuthed = !!user;
 
   /** Push-state navigation helper */
@@ -235,11 +235,12 @@ export default function App() {
 
         {path === "/result" && <GeoQueryResults query={userQuery} />}
 
-        {/* Default homepage */}
-        {path !== "/login" &&
-          path !== "/register" &&
-          path !== "/user" &&
-          path !== "/result" && <HomeView onQuery={handleQuery} />}
+        {path === "/history" && <HistoryPage />}
+
+        {/* Default homepage (mutually exclusive) */}
+        {["/login", "/register", "/user", "/result", "/history"].includes(path)
+          ? null
+          : <HomeView onQuery={handleQuery} />}
       </main>
 
       <Footer brand="GeoQuery" />

--- a/frontend/src/components/layout/TopNav.tsx
+++ b/frontend/src/components/layout/TopNav.tsx
@@ -6,7 +6,6 @@ export type TopNavLink = {
     | "Home"
     | "Dashboard"
     | "History"
-    | "Import"
     | "Result"
     | "Tutorials"
     | "About";
@@ -19,15 +18,14 @@ export type TopNavProps = {
   rightArea?: React.ReactNode;
   isAuthenticated?: boolean;
   onAvatarClick?: () => void;
-  onSignOut?: () => void; // NEW: sign out handler
+  onSignOut?: () => void;
 };
 
-// Map labels to default paths
+// Map labels to default paths (Import removed)
 const LABEL_TO_PATH: Record<TopNavLink["label"], string> = {
   Home: "/",
   Dashboard: "/dashboard",
   History: "/history",
-  Import: "/upload",
   Result: "/result",
   Tutorials: "/tutorials",
   About: "/about",
@@ -122,17 +120,11 @@ export default function TopNav({
   const activePath = useActivePath();
   const [open, setOpen] = useState(false);
 
-  // Filter links: hide History if not authenticated; Import goes to /login for guests
+  // Filter links: hide History if not authenticated
   const filtered = useMemo(() => {
     return links
       .filter((l) => (l.label === "History" ? isAuthenticated : true))
-      .map((l) => {
-        let href = LABEL_TO_PATH[l.label];
-        if (!isAuthenticated && l.label === "Import") {
-          href = "/login";
-        }
-        return { ...l, href };
-      });
+      .map((l) => ({ ...l, href: LABEL_TO_PATH[l.label] }));
   }, [links, isAuthenticated]);
 
   // Handle navigation (pushState)
@@ -150,16 +142,13 @@ export default function TopNav({
   };
 
   return (
-    <header
-      role="banner"
-      className="sticky top-0 z-50 bg-background border-b border-border"
-    >
+    <header role="banner" className="sticky top-0 z-50 bg-background border-b border-border">
       <nav
         className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-14 flex items-center"
         aria-label="Top Navigation"
         role="navigation"
       >
-        {/* Brand name on the left */}
+        {/* Brand */}
         <div className="flex items-center gap-2">
           <a
             href="/"
@@ -181,13 +170,9 @@ export default function TopNav({
               <button
                 key={label}
                 onClick={() => handleNavigate(href, onClick)}
-                className={`px-3 py-2 rounded-md text-sm font-medium transition-colors
-                  ${
-                    active
-                      ? "bg-accent text-foreground"
-                      : "text-foreground/80 hover:bg-accent"
-                  }
-                `}
+                className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  active ? "bg-accent text-foreground" : "text-foreground/80 hover:bg-accent"
+                }`}
                 aria-current={active ? "page" : undefined}
               >
                 {label}
@@ -231,16 +216,16 @@ export default function TopNav({
                 <button
                   key={label}
                   onClick={() => handleNavigate(href, onClick)}
-                  className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium
-                    ${active ? "bg-accent" : "hover:bg-accent"}
-                  `}
+                  className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
+                    active ? "bg-accent" : "hover:bg-accent"
+                  }`}
                   aria-current={active ? "page" : undefined}
                 >
                   {label}
                 </button>
               );
             })}
-            {/* Mobile right area (theme, sign out, avatar) */}
+            {/* Mobile right area */}
             <div className="pt-2 flex items-center gap-3">
               {rightArea ?? (
                 <div className="flex items-center gap-3">
@@ -272,4 +257,5 @@ export default function TopNav({
     </header>
   );
 }
+
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,34 +1,177 @@
-/** Minimal frontend-only auth helpers (no backend involved) */
+/**
+ * Auth utilities for the GeoQuery frontend.
+ * Includes:
+ * - Email/password validation (UI-only)
+ * - Frontend-only "demo auth" (localStorage + salted SHA-256)
+ * - Lightweight session storage helpers (get/set current user)
+ *
+ * IMPORTANT: The "demo auth" is for classroom demos and prototypes only.
+ * Do NOT use this file as-is in production.
+ */
 
+/* =========================
+ * Validation helpers (UI)
+ * ========================= */
+
+/** Basic email validator for UI feedback (not RFC-perfect, but practical). */
+export function validateEmail(email: string): boolean {
+  if (!email) return false;
+  // Simplified check: something@something.domain
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+/**
+ * Password policy used in the UI:
+ * - Length: 8–32
+ * - Contains at least one letter and one number
+ * Adjust as needed for your class/demo requirements.
+ */
+export function validatePassword(pwd: string): boolean {
+  if (typeof pwd !== "string") return false;
+  if (pwd.length < 8 || pwd.length > 32) return false;
+  const hasLetter = /[A-Za-z]/.test(pwd);
+  const hasNumber = /\d/.test(pwd);
+  return hasLetter && hasNumber;
+}
+
+/* =========================================
+ * Session storage for "logged-in" frontend
+ * ========================================= */
+
+/** Minimal representation of a signed-in user on the frontend. */
 export type User = { email: string };
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-// Password rule: 8-32 chars, at least one letter and one number
-const PASS_RE = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d!@#$%^&*()_+\-={}[\]|:;"'<>,.?/~`]{8,32}$/;
+const LS_CURR = "geoqa_current_user";
 
-export function validateEmail(email: string) {
-  return EMAIL_RE.test(email);
-}
-
-export function validatePassword(pwd: string) {
-  return PASS_RE.test(pwd);
-}
-
-const KEY = "geoquery_user";
-
+/** Get the currently "logged-in" user from localStorage (frontend-only). */
 export function getStoredUser(): User | null {
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = localStorage.getItem(LS_CURR);
     return raw ? (JSON.parse(raw) as User) : null;
   } catch {
     return null;
   }
 }
 
-export function setStoredUser(user: User | null) {
-  if (user) {
-    localStorage.setItem(KEY, JSON.stringify(user));
-  } else {
-    localStorage.removeItem(KEY);
+/** Set or clear the current user in localStorage (frontend-only). */
+export function setStoredUser(u: User | null) {
+  if (!u) localStorage.removeItem(LS_CURR);
+  else localStorage.setItem(LS_CURR, JSON.stringify(u));
+}
+
+/* ==========================================================
+ * Demo-only local auth (register/verify in the browser ONLY)
+ * ==========================================================
+ *
+ * This block implements a small "fake backend" so you can
+ * register and login during demos without a server:
+ * - Users are stored in localStorage under `geoqa_users`
+ * - Passwords are salted + hashed with SHA-256 (Web Crypto)
+ * - All logic is visible/modifiable by anyone in DevTools
+ * - Clearing the browser storage removes all accounts
+ */
+
+export type DemoUserRecord = { email: string; saltHex: string; hashHex: string };
+
+const LS_USERS = "geoqa_users";
+
+/** Safe parse of the local user list. */
+function getUsers(): DemoUserRecord[] {
+  try {
+    const raw = localStorage.getItem(LS_USERS);
+    const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+    return Array.isArray(parsed) ? (parsed as DemoUserRecord[]) : [];
+  } catch {
+    return [];
   }
+}
+
+/** Persist the local user list. */
+function setUsers(users: DemoUserRecord[]) {
+  localStorage.setItem(LS_USERS, JSON.stringify(users));
+}
+
+/** Text → UTF-8 bytes. */
+function enc(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+/** Uint8Array → hex string. */
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** hex string → Uint8Array. */
+function fromHex(hex: string): Uint8Array {
+  const clean = hex.trim();
+  if (clean.length % 2 !== 0) throw new Error("Invalid hex length");
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/**
+ * Hash = SHA-256( salt || password )
+ * This is for DEMO ONLY. For real auth:
+ * - Use PBKDF2/scrypt/Argon2 **on the server**
+ * - Never trust a browser-only verification
+ */
+async function hashPassword(password: string, salt: Uint8Array): Promise<Uint8Array> {
+  // Ensure Web Crypto exists (it does in browsers).
+  if (!("crypto" in globalThis) || !("subtle" in crypto)) {
+    throw new Error("Web Crypto API is not available in this environment.");
+  }
+  const body = enc(password);
+  const buf = new Uint8Array(salt.length + body.length);
+  buf.set(salt, 0);
+  buf.set(body, salt.length);
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return new Uint8Array(digest);
+}
+
+/** Constant-time comparison to reduce timing-based differences (still client-side). */
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+/**
+ * Register a new demo user in localStorage.
+ * Returns { ok: true } on success or { ok: false, reason } if the email exists.
+ */
+export async function registerUser(
+  email: string,
+  password: string
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const users = getUsers();
+  const exists = users.find((u) => u.email.toLowerCase() === email.toLowerCase());
+  if (exists) return { ok: false, reason: "Email is already registered." };
+
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const hash = await hashPassword(password, salt);
+
+  users.push({ email, saltHex: toHex(salt), hashHex: toHex(hash) });
+  setUsers(users);
+  return { ok: true };
+}
+
+/**
+ * Verify a user's credentials against the localStorage list.
+ * Returns true if the email exists and the password matches.
+ */
+export async function verifyUser(email: string, password: string): Promise<boolean> {
+  const users = getUsers();
+  const u = users.find((x) => x.email.toLowerCase() === email.toLowerCase());
+  if (!u) return false;
+  const hash = await hashPassword(password, fromHex(u.saltHex));
+  return timingSafeEqual(hash, fromHex(u.hashHex));
+}
+
+/** Utility for demos: clear all locally stored demo users. */
+export function clearAllDemoUsers() {
+  localStorage.removeItem(LS_USERS);
 }

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Github, Linkedin } from "lucide-react";
+
+/** About page: project overview and team members */
+export default function AboutPage() {
+  return (
+    <div className="max-w-5xl mx-auto text-white px-4 sm:px-6 lg:px-8">
+      {/* Project overview */}
+      <section className="mb-12">
+        <h1 className="text-3xl font-semibold mb-4">About the Project</h1>
+        <p className="text-white/80 leading-relaxed">
+          GeoQuery is a capstone project that transforms natural language into geographic insights.
+          The system enables users to query, analyze, and visualize spatial data in an intuitive way.
+          Our team collaborated across frontend and backend to build a user-friendly platform that
+          connects advanced geospatial analytics with a clean, interactive interface.
+        </p>
+      </section>
+
+      {/* Team members */}
+      <section>
+        <h2 className="text-2xl font-semibold mb-6">Our Team</h2>
+
+        {/* Backend team */}
+        <h3 className="text-xl font-semibold mb-4">Backend Team</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+          <Member name="Xudong Zhao" />
+          <Member name="Runzhi Zhao" />
+          <Member
+            name="Zeke Ding"
+            github="https://github.com/Dzx1025"
+            linkedin="https://www.linkedin.com/in/zekeding/"
+          />
+          <Member
+            name="Meitong Jin"
+            github="https://github.com/MeitongJin"
+            linkedin="https://www.linkedin.com/in/meitong-jin-3aba5635a"
+          />
+        </div>
+
+        {/* Frontend team */}
+        <h3 className="text-xl font-semibold mb-4">Frontend Team</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <Member
+            name="Brielle Wang"
+            github="https://github.com/briellewang"
+            linkedin="https://www.linkedin.com/in/brielle-wang-2a640b314"
+          />
+          <Member
+            name="Anandhu Raveendran"
+            github="https://github.com/anandhur26"
+            linkedin="http://www.linkedin.com/in/anandhu-raveendran-b56629222"
+          />
+          <Member
+            name="Yao Qin"
+            github="https://github.com/5km5km"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/** Reusable member card */
+function Member({
+  name,
+  github,
+  linkedin,
+}: {
+  name: string;
+  github?: string;
+  linkedin?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-white/20 bg-white/10 p-5 shadow-sm">
+      <p className="font-medium text-lg mb-3">{name}</p>
+      <div className="flex gap-3">
+        {github && (
+          <a
+            href={github}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2 rounded-lg bg-white/10 hover:bg-white/20"
+            aria-label="GitHub"
+          >
+            <Github className="w-5 h-5" />
+          </a>
+        )}
+        {linkedin && (
+          <a
+            href={linkedin}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2 rounded-lg bg-white/10 hover:bg-white/20"
+            aria-label="LinkedIn"
+          >
+            <Linkedin className="w-5 h-5" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+
+/** Frontend-only history page with demo questions.
+ * Fake items reset on reload; allows delete in-session.
+ */
+export default function HistoryPage() {
+  // Demo questions (reset every reload)
+  const initial = [
+    "Find the largest cities near rivers in Europe",
+    "Show population density of coastal areas in Asia",
+    "What are the highest mountains in South America?",
+  ];
+
+  const [questions, setQuestions] = useState(initial);
+
+  const handleDelete = (idx: number) => {
+    setQuestions((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto text-white">
+      <h1 className="text-2xl font-semibold mb-6">History</h1>
+
+      {questions.length === 0 ? (
+        <p className="text-white/70">No questions yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {questions.map((q, idx) => (
+            <li
+              key={idx}
+              className="flex justify-between items-center rounded-xl bg-white/10 border border-white/20 px-4 py-3"
+            >
+              <span className="text-white/90">{q}</span>
+              <button
+                onClick={() => handleDelete(idx)}
+                className="ml-4 px-3 py-1 text-sm rounded-lg bg-red-500/20 hover:bg-red-500/30 border border-red-500/30 text-red-200"
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -1,3 +1,16 @@
+/**
+ * @deprecated ImportPage
+ *
+ * This component was discussed and the team decided not to implement
+ * the Import feature in the current release.
+ *
+ * The file is kept for reference only and is no longer used in routes
+ * or navigation. Do not add new logic here.
+ *
+ * If the Import functionality is resumed in the future,
+ * please review this implementation carefully or consider a new design.
+ */
+
 import React, { useMemo, useState } from "react";
 
 /** Import page with custom English file upload UI */

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import { validateEmail, validatePassword } from "@/lib/auth";
+import React, { useEffect, useState } from "react";
+import { validateEmail, validatePassword, verifyUser } from "@/lib/auth";
 
-/** Frontend-only login form with basic validation */
+/** Frontend-only login form with improved UX and local verification */
 export default function Login({
   onLogin,
   onGoRegister,
@@ -11,50 +11,114 @@ export default function Login({
 }) {
   const [email, setEmail] = useState("");
   const [pwd, setPwd] = useState("");
+  const [showPwd, setShowPwd] = useState(false);
+  const [remember, setRemember] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
-  const submit = (e: React.FormEvent) => {
+  // Prefill email if previously remembered
+  useEffect(() => {
+    const saved = localStorage.getItem("geoqa_login_email");
+    if (saved) {
+      setEmail(saved);
+      setRemember(true);
+    }
+  }, []);
+
+  const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateEmail(email)) return setErr("Please enter a valid email.");
+    if (!validateEmail(email)) return setErr("Please enter a valid email address.");
     if (!validatePassword(pwd))
-      return setErr("Password must be 8-32 chars, include letters and numbers.");
+      return setErr("Password must be 8–32 characters and include both letters and numbers.");
     setErr(null);
+
+    // Persist remembered email
+    if (remember) localStorage.setItem("geoqa_login_email", email);
+    else localStorage.removeItem("geoqa_login_email");
+
+    setSubmitting(true);
+    const ok = await verifyUser(email, pwd); // local verification (demo-only)
+    setSubmitting(false);
+
+    if (!ok) return setErr("Invalid email or password.");
     onLogin(email);
   };
 
+  const canSubmit = email.trim().length > 0 && pwd.length >= 8 && !submitting;
+
   return (
-    <div className="max-w-md mx-auto bg-white/10 border border-white/20 rounded-xl p-6 text-white">
-      <h1 className="text-2xl font-semibold mb-4">Login</h1>
-      {err && <p className="mb-3 text-red-200">{err}</p>}
-      <form onSubmit={submit} className="space-y-4">
-        <input
-          type="email"
-          className="w-full rounded-md px-3 py-2 bg-white/90 text-gray-800"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          autoComplete="email"
-        />
-        <input
-          type="password"
-          className="w-full rounded-md px-3 py-2 bg-white/90 text-gray-800"
-          placeholder="Password"
-          value={pwd}
-          onChange={(e) => setPwd(e.target.value)}
-          autoComplete="current-password"
-        />
+    <div className="max-w-md mx-auto bg-white/10 border border-white/20 rounded-2xl p-6 text-white shadow-sm">
+      <h1 className="text-2xl font-semibold mb-1">Sign in</h1>
+      <p className="text-white/70 text-sm mb-4">Access your GeoQuery account</p>
+
+      {err && (
+        <div className="mb-4 rounded-lg border border-red-300/40 bg-red-500/10 px-3 py-2 text-sm">
+          {err}
+        </div>
+      )}
+
+      <form onSubmit={submit} className="space-y-4" noValidate>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1 text-white/80">Email</label>
+          <input
+            id="email"
+            type="email"
+            className="w-full rounded-xl px-3 py-2 bg-white/90 text-gray-900 placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-300"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1 text-white/80">Password</label>
+          <div className="relative">
+            <input
+              id="password"
+              type={showPwd ? "text" : "password"}
+              className="w-full rounded-xl px-3 py-2 bg-white/90 text-gray-900 placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-300 pr-24"
+              placeholder="••••••••"
+              value={pwd}
+              onChange={(e) => setPwd(e.target.value)}
+              autoComplete="current-password"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPwd((v) => !v)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg px-2 py-1 text-xs font-medium bg-gray-900/80 text-white hover:bg-gray-900"
+              aria-label={showPwd ? "Hide password" : "Show password"}
+            >
+              {showPwd ? "Hide" : "Show"}
+            </button>
+          </div>
+          <div className="mt-2 flex items-center justify-between">
+            <label className="inline-flex items-center gap-2 text-sm text-white/80">
+              <input type="checkbox" checked={remember} onChange={(e) => setRemember(e.target.checked)} />
+              Remember email
+            </label>
+            <button
+              type="button"
+              className="text-sm underline text-white/80 hover:text-white"
+              onClick={() => alert("This is a frontend-only demo.")}
+            >
+              Forgot password?
+            </button>
+          </div>
+        </div>
+
         <button
           type="submit"
-          className="w-full bg-white text-purple-700 font-medium py-2 rounded-md hover:bg-gray-100"
+          disabled={!canSubmit}
+          className="w-full rounded-xl bg-white text-purple-700 font-medium py-2.5 shadow-sm hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          Sign in
+          {submitting ? "Signing in…" : "Sign in"}
         </button>
       </form>
+
       <div className="mt-4 text-sm text-white/80">
         Don’t have an account?{" "}
-        <button onClick={onGoRegister} className="underline hover:text-white">
-          Sign up
-        </button>
+        <button onClick={onGoRegister} className="underline hover:text-white">Sign up</button>
       </div>
     </div>
   );

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import { validateEmail, validatePassword } from "@/lib/auth";
+import React, { useMemo, useState } from "react";
+import { validateEmail, validatePassword, registerUser } from "@/lib/auth";
 
-/** Frontend-only register form; after success, considered logged-in */
+/** Frontend-only register form with password strength and local storage */
 export default function Register({
   onRegister,
   onGoLogin,
@@ -12,59 +12,141 @@ export default function Register({
   const [email, setEmail] = useState("");
   const [pwd, setPwd] = useState("");
   const [pwd2, setPwd2] = useState("");
+  const [showPwd, setShowPwd] = useState(false);
+  const [agree, setAgree] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
-  const submit = (e: React.FormEvent) => {
+  // Simple client-side strength indicator (length + character variety)
+  const strength = useMemo(() => {
+    let score = 0;
+    if (pwd.length >= 8) score++;
+    if (/[A-Z]/.test(pwd)) score++;
+    if (/[a-z]/.test(pwd)) score++;
+    if (/\d/.test(pwd)) score++;
+    if (/[^A-Za-z0-9]/.test(pwd)) score++;
+    return Math.min(score, 5);
+  }, [pwd]);
+
+  const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateEmail(email)) return setErr("Please enter a valid email.");
+    if (!validateEmail(email)) return setErr("Please enter a valid email address.");
     if (!validatePassword(pwd))
-      return setErr("Password must be 8-32 chars, include letters and numbers.");
+      return setErr("Password must be 8–32 characters and include both letters and numbers.");
     if (pwd !== pwd2) return setErr("Passwords do not match.");
+    if (!agree) return setErr("Please agree to the Terms before continuing.");
     setErr(null);
+
+    setSubmitting(true);
+    const res = await registerUser(email, pwd); // local registration (demo-only)
+    setSubmitting(false);
+
+    if (!res.ok) return setErr(res.reason);
     onRegister(email); // consider the user logged in
   };
 
+  const canSubmit =
+    email.trim().length > 0 &&
+    pwd.length >= 8 &&
+    pwd2.length >= 8 &&
+    agree &&
+    !submitting;
+
   return (
-    <div className="max-w-md mx-auto bg-white/10 border border-white/20 rounded-xl p-6 text-white">
-      <h1 className="text-2xl font-semibold mb-4">Register</h1>
-      {err && <p className="mb-3 text-red-200">{err}</p>}
-      <form onSubmit={submit} className="space-y-4">
-        <input
-          type="email"
-          className="w-full rounded-md px-3 py-2 bg-white/90 text-gray-800"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          autoComplete="email"
-        />
-        <input
-          type="password"
-          className="w-full rounded-md px-3 py-2 bg-white/90 text-gray-800"
-          placeholder="Password"
-          value={pwd}
-          onChange={(e) => setPwd(e.target.value)}
-          autoComplete="new-password"
-        />
-        <input
-          type="password"
-          className="w-full rounded-md px-3 py-2 bg-white/90 text-gray-800"
-          placeholder="Confirm Password"
-          value={pwd2}
-          onChange={(e) => setPwd2(e.target.value)}
-          autoComplete="new-password"
-        />
+    <div className="max-w-md mx-auto bg-white/10 border border-white/20 rounded-2xl p-6 text-white shadow-sm">
+      <h1 className="text-2xl font-semibold mb-1">Create your account</h1>
+      <p className="text-white/70 text-sm mb-4">Join GeoQuery and start exploring</p>
+
+      {err && (
+        <div className="mb-4 rounded-lg border border-red-300/40 bg-red-500/10 px-3 py-2 text-sm">
+          {err}
+        </div>
+      )}
+
+      <form onSubmit={submit} className="space-y-4" noValidate>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1 text-white/80">Email</label>
+          <input
+            id="email"
+            type="email"
+            className="w-full rounded-xl px-3 py-2 bg-white/90 text-gray-900 placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-300"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1 text-white/80">Password</label>
+          <div className="relative">
+            <input
+              id="password"
+              type={showPwd ? "text" : "password"}
+              className="w-full rounded-xl px-3 py-2 bg-white/90 text-gray-900 placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-300 pr-24"
+              placeholder="At least 8 characters"
+              value={pwd}
+              onChange={(e) => setPwd(e.target.value)}
+              autoComplete="new-password"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPwd((v) => !v)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg px-2 py-1 text-xs font-medium bg-gray-900/80 text-white hover:bg-gray-900"
+              aria-label={showPwd ? "Hide password" : "Show password"}
+            >
+              {showPwd ? "Hide" : "Show"}
+            </button>
+          </div>
+
+          {/* Strength meter */}
+          <div className="mt-2">
+            <div className="h-1.5 w-full bg-white/20 rounded-full overflow-hidden">
+              <div
+                className="h-full transition-all"
+                style={{
+                  width: `${(strength / 5) * 100}%`,
+                  background:
+                    strength < 3 ? "rgba(239,68,68,0.9)" : strength < 4 ? "rgba(234,179,8,0.95)" : "rgba(34,197,94,0.95)",
+                }}
+              />
+            </div>
+            <p className="mt-1 text-xs text-white/70">
+              {strength < 3 ? "Weak" : strength < 4 ? "Medium" : "Strong"} password
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="password2" className="block text-sm mb-1 text-white/80">Confirm password</label>
+          <input
+            id="password2"
+            type="password"
+            className="w-full rounded-xl px-3 py-2 bg-white/90 text-gray-900 placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-300"
+            placeholder="Re-enter your password"
+            value={pwd2}
+            onChange={(e) => setPwd2(e.target.value)}
+            autoComplete="new-password"
+          />
+        </div>
+
+        <label className="inline-flex items-center gap-2 text-sm text-white/80">
+          <input type="checkbox" checked={agree} onChange={(e) => setAgree(e.target.checked)} />
+          I agree to the Terms and Privacy Policy
+        </label>
+
         <button
           type="submit"
-          className="w-full bg-white text-purple-700 font-medium py-2 rounded-md hover:bg-gray-100"
+          disabled={!canSubmit}
+          className="w-full rounded-xl bg-white text-purple-700 font-medium py-2.5 shadow-sm hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          Create account
+          {submitting ? "Creating…" : "Create account"}
         </button>
       </form>
+
       <div className="mt-4 text-sm text-white/80">
         Already have an account?{" "}
-        <button onClick={onGoLogin} className="underline hover:text-white">
-          Sign in
-        </button>
+        <button onClick={onGoLogin} className="underline hover:text-white">Sign in</button>
       </div>
     </div>
   );

--- a/frontend/src/pages/User.tsx
+++ b/frontend/src/pages/User.tsx
@@ -1,14 +1,164 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
-/** Placeholder user profile page */
+/** User profile & preferences page (frontend-only; no backend required) */
 export default function UserPage({ email }: { email: string }) {
+  // Profile
+  const [displayName, setDisplayName] = useState("");
+  const [editing, setEditing] = useState(false);
+
+  // Preferences
+  const [theme, setTheme] = useState<"system" | "light" | "dark">("system");
+  const [compact, setCompact] = useState(false);
+
+  // Load persisted data
+  useEffect(() => {
+    const savedName = localStorage.getItem("geoqa_display_name");
+    if (savedName) setDisplayName(savedName);
+
+    const savedTheme = (localStorage.getItem("geoqa_theme") as "system" | "light" | "dark") || "system";
+    setTheme(savedTheme);
+
+    const savedCompact = localStorage.getItem("geoqa_compact") === "1";
+    setCompact(savedCompact);
+  }, []);
+
+  // Apply theme to document root (demo-only)
+  useEffect(() => {
+    const root = document.documentElement;
+    const desired =
+      theme === "system"
+        ? (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+        : theme;
+
+    if (desired === "dark") root.classList.add("dark");
+    else root.classList.remove("dark");
+
+    localStorage.setItem("geoqa_theme", theme);
+  }, [theme]);
+
+  // Persist and expose density to the document root
+  useEffect(() => {
+    localStorage.setItem("geoqa_compact", compact ? "1" : "0");
+    document.documentElement.setAttribute("data-density", compact ? "compact" : "comfortable");
+  }, [compact]);
+
+  const initials = useMemo(() => {
+    const src = displayName || email;
+    const parts = src.replace(/@.*/, "").split(/[.\s_-]+/).filter(Boolean);
+    return parts.length === 1 ? parts[0].slice(0, 2).toUpperCase() : (parts[0][0] + parts[1][0]).toUpperCase();
+  }, [displayName, email]);
+
+  const saveProfile = () => {
+    localStorage.setItem("geoqa_display_name", displayName.trim());
+    setEditing(false);
+  };
+
   return (
-    <div className="max-w-3xl mx-auto text-white">
-      <h1 className="text-3xl font-semibold mb-4">User</h1>
-      <p className="text-white/80">Signed in as: {email}</p>
-      <p className="mt-4 text-white/70">
-        This is a placeholder user page. Future profile and settings will go here.
-      </p>
+    <div className="max-w-5xl mx-auto text-white px-4 sm:px-6 lg:px-8">
+      {/* Header */}
+      <header className="mb-6">
+        <h1 className="text-3xl font-semibold tracking-tight">Account</h1>
+        <p className="text-white/70 mt-1 text-sm">Manage your profile and preferences</p>
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        {/* Profile card */}
+        <section className="md:col-span-1 rounded-2xl border border-white/20 bg-white/10 p-5 shadow-sm">
+          <div className="flex items-center gap-4">
+            <div className="h-14 w-14 rounded-xl bg-white/20 flex items-center justify-center text-xl font-bold">
+              {initials}
+            </div>
+            <div>
+              <div className="text-base font-medium">{displayName || "Unnamed user"}</div>
+              <div className="text-sm text-white/80">{email}</div>
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            <label className="block text-sm text-white/80">Display name</label>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              disabled={!editing}
+              className={`w-full rounded-xl px-3 py-2 bg-white/90 text-gray-900 placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-300 ${
+                !editing ? "opacity-75 cursor-not-allowed" : ""
+              }`}
+              placeholder="Your name"
+            />
+            <div className="flex gap-2">
+              {!editing ? (
+                <button
+                  type="button"
+                  className="rounded-xl px-3 py-2 text-sm font-medium bg-white text-purple-700 hover:bg-gray-100"
+                  onClick={() => setEditing(true)}
+                >
+                  Edit
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="rounded-xl px-3 py-2 text-sm font-medium bg-white text-purple-700 hover:bg-gray-100"
+                    onClick={saveProfile}
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-xl px-3 py-2 text-sm font-medium hover:bg-white/20 border border-white/30"
+                    onClick={() => {
+                      setEditing(false);
+                      setDisplayName(localStorage.getItem("geoqa_display_name") || "");
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* Preferences */}
+        <section className="md:col-span-2 rounded-2xl border border-white/20 bg-white/10 p-5 shadow-sm">
+          <h2 className="text-lg font-semibold">Preferences</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm text-white/80 mb-1">Theme</label>
+              <div className="flex gap-2">
+                {(["system", "light", "dark"] as const).map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setTheme(t)}
+                    className={`rounded-xl px-3 py-2 text-sm font-medium border ${
+                      theme === t ? "bg-white text-purple-700 border-white" : "border-white/30 hover:bg-white/20"
+                    }`}
+                    aria-pressed={theme === t}
+                  >
+                    {t[0].toUpperCase() + t.slice(1)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm text-white/80 mb-1">Layout density</label>
+              <label className="inline-flex items-center gap-2 text-sm text-white/80">
+                <input type="checkbox" checked={compact} onChange={(e) => setCompact(e.target.checked)} />
+                Compact mode
+              </label>
+              <p className="mt-2 text-xs text-white/70 leading-5">
+                Compact mode reduces paddings, gaps and sometimes font sizes across the UI to show more information per
+                screen. It is remembered in this browser and can be read via the{" "}
+                <code className="px-1 rounded bg-white/10">data-density</code> attribute on the{" "}
+                <code className="px-1 rounded bg-white/10">&lt;html&gt;</code> element.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR implements new pages, frontend-only authentication, and style refinements for the GeoQuery frontend.  

## Changes
- **About Page**
  - Added project overview and team introduction
  - Team members grouped into Backend and Frontend
  - GitHub and LinkedIn links via icons

- **History Page**
  - Displays seeded demo questions
  - Supports in-session delete functionality
  - Resets on page reload

- **Auth (Frontend-only)**
  - Updated `Login` and `Register` pages to use `auth.ts` localStorage helpers
  - Allows demo-only user validation without backend

- **UI Refinements**
  - Improved TopNav and Footer layout
  - Introduced mutually exclusive routing in `App.tsx` to prevent overlapping pages
  - Updated User page (removed recent activity, clarified compact mode)
  - General layout/spacing and font readability adjustments

## Acceptance Criteria
- `/about` shows project overview and team members  
- `/history` shows demo questions with delete option  
- Register/Login works locally with localStorage-based validation  
- UI refinements applied consistently  
- Routes render exclusively without overlap  

## Notes
- Features are demo-only (localStorage-based).  
- Future iterations may connect to backend APIs.  

Closes #40 